### PR TITLE
prevent forcing external libraries to be loaded

### DIFF
--- a/.github/workflows/build_appimage.yml
+++ b/.github/workflows/build_appimage.yml
@@ -158,6 +158,8 @@ jobs:
         LIBGL_DRIVERS_PATH=${SHARUN_DIR}/shared/lib/dri
         GIO_MODULE_DIR=${SHARUN_DIR}/lib/x86_64-linux-gnu/gio/modules/
         GSETTINGS_BACKEND=memory
+        unset LD_LIBRARY_PATH
+        unset LD_PRELOAD
         EOF
         # NOTE: sharun should already set GIO_MODULE_DIR automatically
         # LOCPATH=${SHARUN_DIR}/lib/locale:${SHARUN_DIR}/share/locale # This makes PrusaSlicer fail


### PR DESCRIPTION
Tested it by preloading some libs to cause the app to crash and it works when this is added.

[this thing that an application does](https://github.com/prusa3d/PrusaSlicer/issues/13653#issuecomment-2563591774)


